### PR TITLE
RF: use git clone instead of download of a master to make possible to trace analysis script version

### DIFF
--- a/Simple_Prep.sh
+++ b/Simple_Prep.sh
@@ -16,8 +16,8 @@ conda config --add channels conda-forge
 # Get the repo and Create the specific versioned python environment
 echo "Getting the analysis repo"
 
-curl -OksSL https://github.com/ReproNim/simple_workflow/archive/master.zip
-unzip master.zip
+# Checkout the repository to gain traceable version of the analysis script
+git clone https://github.com/ReproNim/simple_workflow simple_workflow-master
 cd simple_workflow-master
 
 echo "Creating specificly versioned Python environment"


### PR DESCRIPTION
ATM script just downloads master zipball of whatever master revision is, which makes it difficult if not impossible to "identify" for a specific version.  Checking out git repository allows to get exact version definition for the file (and any supplemental file in here it might use)