### PR TITLE
BF: make Simple_Prep_docker run on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ release with FSL 5.0.8-3 as it was available in March of 2015:
 ./Simple_Prep_docker jessie 20150306T060524Z
 ```
 
-which will generate a local docker image `repronim:simple_prep_USER_jessie_20150306T060524Z`
-(`USER` will correspond to your user name), with all necessary for computation
+which will generate a local docker image `repronim:simple_prep_${USER}_jessie_20150306T060524Z`
+(`${USER}` will correspond to your user name), with all necessary for computation
 components installed.
 
 #### Run the demo
@@ -99,10 +99,10 @@ You can normally run a demo with only **one additional step** necessary -- setti
 environment variables (to point to FSL binaries and enable  conda environment):
 
 ```bash
-docker run -it --rm repronim:simple_prep_USER_jessie_20150306T060524Z /bin/bash -c '
-  . setup_environment;
-  cd simple_workflow-master
-  && python run_demo_workflow.py --key 11an55u9t2TAf0EV2pHN0vOd8Ww2Gie-tHp9xGULh_dA
+docker run -it --rm repronim:simple_prep_${USER}_jessie_20150306T060524Z /bin/bash -c ' \
+  . setup_environment; \
+  cd simple_workflow-master \
+  && python run_demo_workflow.py --key 11an55u9t2TAf0EV2pHN0vOd8Ww2Gie-tHp9xGULh_dA \
   && python check_output.py'
 ```
 

--- a/Simple_Prep_docker
+++ b/Simple_Prep_docker
@@ -44,18 +44,24 @@ sed -e "s,DL_DIST,$DL_DIST,g" \
 
 if [ ! -z "$DL_DATE" ]; then
 {
-    # replace with snapshots
-    echo "sed -i -e 's,http://neuro.debian.net/debian/* ,http://snapshot-neuro.debian.net:5002/archive/neurodebian/$DL_DATE/ ,g' etc/apt/sources.list.d/neurodebian.sources.list;"
+    # replace with snapshots.  Cannot use -i due to OSX but since done inside the container
+    # should be safe just to use some explicit /tmp/apt.sources
+    echo "sed -e 's,http://neuro.debian.net/debian/* ,http://snapshot-neuro.debian.net:5002/archive/neurodebian/$DL_DATE/ ,g' etc/apt/sources.list.d/neurodebian.sources.list > /tmp/apt.sources; mv /tmp/apt.sources etc/apt/sources.list.d/neurodebian.sources.list"
     # for now we need to knock to expose snapshots repository
     echo "curl -s http://neuro.debian.net/_files/knock-snapshots;"
     # TODO: figure out and add snapshot for DL_DIST itself if available and force possible downgrade somehow
     echo "eatmydata apt-get update; eatmydata apt-get dist-upgrade -y;"
 } | while read aptline; do
-    sed-i "$dockerfile" -e "s|\(\(.*\)DL_APT\(.*\)\)|\2$aptline\3\
+    # on OSX cannot use \n to get a newline in sed, so doing POSIX way, although also escaping trailing \
+    # so it is in effect within sed-i call
+    sed-i "$dockerfile" -e "s|\(\(.*\)DL_APT\(.*\)\)|\2$aptline\3\\
 \1|g"
     :
 done
 fi
+
+# for debugging
+# cat $dockerfile
 sed-i "$dockerfile" -e '/DL_APT/d'
 
 tag_=simple_prep_${USER}_${DL_DIST}_${DL_DATE}

--- a/Simple_Prep_docker
+++ b/Simple_Prep_docker
@@ -16,12 +16,22 @@ export PS4=+
 #set -x
 set -u
 
+# a little helper since sed on OSX does not have sed -i
+# for in-place modifications.  Note that filename here comes first
+# just to ease scripting
+sed-i () {
+  filename=$1
+  tfilename=$(mktemp -t sed_replace.XXXXXXXXX)
+  shift
+  sed "$@" "$filename" >| "$tfilename"
+  mv "$tfilename" "$filename"
+}
+
 DL_DIST=${1:-jessie}
 DL_DATE=${2:-}
 
-topdir=$(readlink -f `dirname $0`)
 cd `dirname $0`
-dockerfile=$topdir/Simple_Prep_docker-Dockerfile
+dockerfile=./Simple_Prep_docker-Dockerfile
 # echo "D: $DL_APT"
 # Some substitutes aren't used but left for possibly later use
 sed -e "s,DL_DIST,$DL_DIST,g" \
@@ -41,11 +51,12 @@ if [ ! -z "$DL_DATE" ]; then
     # TODO: figure out and add snapshot for DL_DIST itself if available and force possible downgrade somehow
     echo "eatmydata apt-get update; eatmydata apt-get dist-upgrade -y;"
 } | while read aptline; do
-    sed -i -e "s|\(\(.*\)DL_APT\(.*\)\)|\2$aptline\3\n\1|g" $dockerfile
+    sed-i "$dockerfile" -e "s|\(\(.*\)DL_APT\(.*\)\)|\2$aptline\3\
+\1|g"
     :
 done
 fi
-sed -e '/DL_APT/d' -i $dockerfile
+sed-i "$dockerfile" -e '/DL_APT/d'
 
 tag_=simple_prep_${USER}_${DL_DIST}_${DL_DATE}
 tag=repronim:${tag_}

--- a/Simple_Prep_docker
+++ b/Simple_Prep_docker
@@ -44,9 +44,8 @@ sed -e "s,DL_DIST,$DL_DIST,g" \
 
 if [ ! -z "$DL_DATE" ]; then
 {
-    # replace with snapshots.  Cannot use -i due to OSX but since done inside the container
-    # should be safe just to use some explicit /tmp/apt.sources
-    echo "sed -e 's,http://neuro.debian.net/debian/* ,http://snapshot-neuro.debian.net:5002/archive/neurodebian/$DL_DATE/ ,g' etc/apt/sources.list.d/neurodebian.sources.list > /tmp/apt.sources; mv /tmp/apt.sources etc/apt/sources.list.d/neurodebian.sources.list"
+    # replace with snapshots.  Since ran inside the container, sed -i should be ok
+    echo "sed -i -e 's,http://neuro.debian.net/debian/* ,http://snapshot-neuro.debian.net:5002/archive/neurodebian/$DL_DATE/ ,g' etc/apt/sources.list.d/neurodebian.sources.list"
     # for now we need to knock to expose snapshots repository
     echo "curl -s http://neuro.debian.net/_files/knock-snapshots;"
     # TODO: figure out and add snapshot for DL_DIST itself if available and force possible downgrade somehow


### PR DESCRIPTION
as @khinsen  pointed out -- dockerfile preparation script doesn't work on OSX .  This is a PR to address that

- [x]  no sed -i and readlink -f
- [x] check if it works and fix the rest of OSX compatibility issues
- [x] double check back on Linux systems that it works as expected

Closes #17 
Relates to #15 