### PR TITLE
Fixing up Dockerfile and SimplePrep.sh to avoid missing components

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN bash -c "sed -i -e 's,http://neuro.debian.net/debian/* ,http://snapshot-neur
 RUN bash -c "curl -s http://neuro.debian.net/_files/knock-snapshots;"
 RUN bash -c "eatmydata apt-get update; eatmydata apt-get dist-upgrade -y;"
 # We might be just fine with the core here
-RUN bash -c "eatmydata apt-get install -y -q fsl-core fsl-first-data"
+RUN bash -c "eatmydata apt-get install -y -q fsl-core fsl-first-data fsl-mni152-templates"
 
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /boot /media /mnt /srv

--- a/Simple_Prep.sh
+++ b/Simple_Prep.sh
@@ -22,10 +22,16 @@ echo "FSL bet is available"
 
 # Check if first models are available
 
-if ! /bin/ls $FSLDIR/data/first/models* | grep -q .; then
+if ! /bin/ls $FSLDIR/data/first/models* >/dev/null; then
     errorout "No first data found (fsl-first-data package on Debians)"
 fi
 echo "FSL first data found"
+
+if ! /bin/ls $FSLDIR/data/standard/MNI152_T1_1mm.nii.gz >/dev/null; then
+    errorout "No FSL MNI templates found (fsl-mni152-templates package on Debians)"
+fi
+echo "FSL MNI templates found"
+
 
 # Check if curl is available
 [ ! $(command -v curl) ] && echo "No curl: Make sure a version of curl is installed and available." && kill -INT $$

--- a/Simple_Prep.sh
+++ b/Simple_Prep.sh
@@ -2,15 +2,30 @@
 
 set -e
 
+function errorout() {
+    echo
+    echo "ERROR: $@" >&2
+    echo "Exiting"
+    echo
+    kill -INT $$
+}
+
 # Check if FSL is available
 if [ ! $(command -v bet) ]; then
     if [ -f /etc/fsl/fsl.sh ]; then
         source /etc/fsl/fsl.sh
     else
-        echo "No bet: Make sure an FSL version - https://fsl.fmrib.ox.ac.uk/ - is installed and available." && kill -INT $$
+        errorout "No bet: Make sure an FSL version - https://fsl.fmrib.ox.ac.uk/ - is installed and available."
     fi
 fi
 echo "FSL bet is available"
+
+# Check if first models are available
+
+if ! /bin/ls $FSLDIR/data/first/models* | grep -q .; then
+    errorout "No first data found (fsl-first-data package on Debians)"
+fi
+echo "FSL first data found"
 
 # Check if curl is available
 [ ! $(command -v curl) ] && echo "No curl: Make sure a version of curl is installed and available." && kill -INT $$


### PR DESCRIPTION
on ubuntu, recommends might not be installed by default, so mni152 templates would be missing

in SimplePrep.sh introduced verification that those needed components are indeed installed (if there is FSL for OSX, would be nice if someone could test it)