### PR TITLE
Tweak to make sure Simple_prep.sh works outside of main repo

### DIFF
--- a/Simple_Prep.sh
+++ b/Simple_Prep.sh
@@ -32,19 +32,39 @@ if ! /bin/ls $FSLDIR/data/standard/MNI152_T1_1mm.nii.gz >/dev/null; then
 fi
 echo "FSL MNI templates found"
 
-
 # Check if curl is available
 [ ! $(command -v curl) ] && echo "No curl: Make sure a version of curl is installed and available." && kill -INT $$
 echo "curl is available"
 
-echo "Creating local directory simple_workflow to create and execute environment"
-mkdir -p simple_workflow && cd simple_workflow
+if [ ! -e ./expected_output ]; then
+    echo "Creating local directory 'workflow' to host and execute environment"
+    mkdir -p workflow
+    cd workflow
+
+    # Get the repo and Create the specific versioned python environment
+    echo "Getting the analysis repo"
+    if [ $(command -v git) ]; then
+       #git clone https://github.com/ReproNim/simple_workflow scripts
+       cd scripts
+       git checkout a26e0c01227c8baa0756b9e95a0442d69e9c9e10
+    elif [ $(command -v unzip) ]; then
+       curl -ssL -o workdir.zip https://github.com/ReproNim/simple_workflow/archive/a26e0c01227c8baa0756b9e95a0442d69e9c9e10.zip
+       unzip workdir.zip && rm workdir.zip
+       mv simple_workflow-a26e0c01227c8baa0756b9e95a0442d69e9c9e10 scripts
+    else
+       echo "Neither git not unzip available. Cannot download scripts"
+       cd ../.. & rm -Rf workflow
+       exit 1
+    fi
+    cd ..
+fi
 
 # Setup standalone python environment
 echo "Setting up standalone conda Python environment"
 
 if [ ! -e miniconda ]; then
     echo "Downloading miniconda"
+
     if [ `uname` == 'Darwin' ]; then
         curl -sSL -o miniconda.sh http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh
     else
@@ -57,23 +77,7 @@ if [ ! -e miniconda ]; then
     rm miniconda.sh
 fi
 PATH=$PWD/miniconda/bin:$PATH
-
-# Get the repo and Create the specific versioned python environment
-if [ ! -e scripts/expected_output ]; then
-    echo "Getting the analysis repo"
-    if [ $(command -v git) ]; then
-       git clone https://github.com/ReproNim/simple_workflow scripts
-       cd scripts
-       git checkout a26e0c01227c8baa0756b9e95a0442d69e9c9e10
-    elif [ $(command -v unzip) ]; then
-       curl -ssL -o workdir.zip https://github.com/ReproNim/simple_workflow/archive/a26e0c01227c8baa0756b9e95a0442d69e9c9e10.zip
-       unzip workdir.zip && rm workdir.zip
-       mv simple_workflow-a26e0c01227c8baa0756b9e95a0442d69e9c9e10 scripts
-    else
-       echo "Neither git not unzip available. Cannot download scripts"
-       exit 1
-    fi
-fi
+echo "Updated path to:" $PATH
 
 echo "Creating and activating versioned Python environment"
 if [ ! -e miniconda/envs/bh_demo/bin/nipype_display_crash ]; then
@@ -93,19 +97,27 @@ to check.
 
 ---- END SIMPLE_PREP SCRIPT WARNING ----"
     fi
-    conda env create -f scripts/environment.yml
+    if [ ! -e ./expected_output ]; then
+    	conda env create -f scripts/environment.yml
+    else
+        conda env create -f ./environment.yml
+    fi
     conda clean -tipsy
 fi
 
 if [ "$1" == "test" ]; then
     PATH=$PWD/miniconda/envs/bh_demo/bin:$PATH
-    cd scripts
+    if [ ! -e ./expected_output ]; then
+        cd scripts
+    fi
     python run_demo_workflow.py --key 11an55u9t2TAf0EV2pHN0vOd8Ww2Gie-tHp9xGULh_dA -n 1 && \
     python check_output.py --ignoremissing
 fi
 if [ "$1" == "replay" ]; then
     PATH=$PWD/miniconda/envs/bh_demo/bin:$PATH
-    cd scripts
+    if [ ! -e ./expected_output ]; then
+        cd scripts
+    fi
     python run_demo_workflow.py --key 11an55u9t2TAf0EV2pHN0vOd8Ww2Gie-tHp9xGULh_dA && \
     python check_output.py
 fi

--- a/environment.yml
+++ b/environment.yml
@@ -1,5 +1,6 @@
 name: bh_demo
 channels:
+- anaconda
 - conda-forge
 - defaults
 dependencies:


### PR DESCRIPTION
The original design of simple_prep.sh was assuming that the user would not have cloned the repo, and simply used the script. The modifications make it such that:
- if the user calls simple_prep.sh outside of the repo, it creates a folder "workflow" to host "miniconda" and "scripts",
- if the user calls simple_prep.sh from inside the repo (because they would have cloned from github), it does not git clone again, uses local files and store miniconda inside the same folder.